### PR TITLE
Artist Schema and Queries

### DIFF
--- a/data-sources/Spotify.js
+++ b/data-sources/Spotify.js
@@ -49,6 +49,42 @@ class SpotifyAPI extends RESTDataSource {
 
     return user;
   }
+
+  async getArtist(artist_id) {
+    console.log(`getArtist: ${artist_id}`);
+
+    const artist = await this.get(`/artists/${artist_id}`);
+
+    return artist;
+  }
+
+  async getArtistAlbums(artist_id) {
+    console.log(`getArtistAlbums: ${artist_id}`);
+
+    const albums = await this.get(`/artists/${artist_id}/albums`);
+
+    return albums;
+  }
+
+  async getRelatedArtists(artist_id) {
+    console.log(`getRelatedArtists: ${artist_id}`);
+
+    const related_artists = await this.get(
+      `/artists/${artist_id}/related-artists`
+    );
+
+    return related_artists.artists;
+  }
+
+  async getArtistsTopTracks(artist_id, country) {
+    console.log(`getRelatedArtists: ${artist_id}`);
+
+    const top_tracks = await this.get(
+      `/artists/${artist_id}/top-tracks?country=${country}`
+    );
+
+    return top_tracks.tracks;
+  }
 }
 
 export default SpotifyAPI;

--- a/schema/Album/index.js
+++ b/schema/Album/index.js
@@ -1,0 +1,4 @@
+import resolvers from './resolvers';
+import typeDefs from './typeDefs';
+
+export { resolvers, typeDefs };

--- a/schema/Album/resolvers.js
+++ b/schema/Album/resolvers.js
@@ -1,0 +1,3 @@
+const resolvers = {};
+
+export default resolvers;

--- a/schema/Album/typeDefs.js
+++ b/schema/Album/typeDefs.js
@@ -1,0 +1,41 @@
+import { gql } from 'apollo-server-express';
+
+const typeDefs = gql`
+  type Album {
+    id: String!
+    name: String!
+    album_type: String!
+    artists: [Artist]!
+    total_tracks: Int!
+    tracks: [Tracks]
+    label: String!
+    popularity: Int!
+    release_date: String!
+    release_date_precision: String
+    available_markets: [String]
+    copyrights: [Copyrights]
+    external_ids: ExternalIds
+    external_urls: Url
+    genres: [String]
+    href: String!
+    images: [Image]
+    type: String!
+    uri: String!
+  }
+
+  type Copyrights {
+    text: String!
+    type: String!
+  }
+
+  type ExternalIds {
+    upc: String!
+  }
+
+  type Tracks {
+    href: String!
+    items: [Track!]
+  }
+`;
+
+export default typeDefs;

--- a/schema/Artist/index.js
+++ b/schema/Artist/index.js
@@ -1,0 +1,4 @@
+import resolvers from './resolvers';
+import typeDefs from './typeDefs';
+
+export { resolvers, typeDefs };

--- a/schema/Artist/resolvers.js
+++ b/schema/Artist/resolvers.js
@@ -1,0 +1,16 @@
+const resolvers = {
+  Query: {
+    artist: async (_source, { artist_id }, { dataSources }) =>
+      dataSources.spotifyAPI.getArtist(artist_id)
+  },
+  Artist: {
+    albums: async (artist, _args, { dataSources }) =>
+      dataSources.spotifyAPI.getArtistAlbums(artist.id),
+    related_artists: async (artist, _args, { dataSources }) =>
+      dataSources.spotifyAPI.getRelatedArtists(artist.id),
+    top_tracks: async (artist, { country }, { dataSources }) =>
+      dataSources.spotifyAPI.getArtistsTopTracks(artist.id, country)
+  }
+};
+
+export default resolvers;

--- a/schema/Artist/typeDefs.js
+++ b/schema/Artist/typeDefs.js
@@ -1,0 +1,30 @@
+import { gql } from 'apollo-server-express';
+
+const typeDefs = gql`
+  extend type Query {
+    artist(artist_id: String!): Artist
+  }
+
+  type Artist {
+    id: String!
+    name: String!
+    type: String!
+    uri: String!
+    images: [Image]
+    href: String
+    followers: Followers
+    external_urls: Url
+    popularity: Int
+    genres: [String]
+    albums: Albums
+    related_artists: [Artist]
+    top_tracks(country: String = "GB"): [Track]
+  }
+
+  type Albums {
+    href: String!
+    items: [Album]
+  }
+`;
+
+export default typeDefs;

--- a/schema/Shared/index.js
+++ b/schema/Shared/index.js
@@ -1,0 +1,4 @@
+import resolvers from './resolvers';
+import typeDefs from './typeDefs';
+
+export { resolvers, typeDefs };

--- a/schema/Shared/resolvers.js
+++ b/schema/Shared/resolvers.js
@@ -1,0 +1,3 @@
+const resolvers = {};
+
+export default resolvers;

--- a/schema/Shared/typeDefs.js
+++ b/schema/Shared/typeDefs.js
@@ -1,0 +1,20 @@
+import { gql } from 'apollo-server-express';
+
+const typeDefs = gql`
+  type Image {
+    height: Int
+    url: String!
+    width: Int
+  }
+
+  type Followers {
+    href: String
+    total: Int
+  }
+
+  type Url {
+    spotify: String
+  }
+`;
+
+export default typeDefs;

--- a/schema/Track/index.js
+++ b/schema/Track/index.js
@@ -1,0 +1,4 @@
+import resolvers from './resolvers';
+import typeDefs from './typeDefs';
+
+export { resolvers, typeDefs };

--- a/schema/Track/resolvers.js
+++ b/schema/Track/resolvers.js
@@ -1,0 +1,3 @@
+const resolvers = {};
+
+export default resolvers;

--- a/schema/Track/typeDefs.js
+++ b/schema/Track/typeDefs.js
@@ -1,0 +1,12 @@
+import { gql } from 'apollo-server-express';
+
+const typeDefs = gql`
+  type Track {
+    id: String!
+    name: String!
+    type: String!
+    uri: String!
+  }
+`;
+
+export default typeDefs;

--- a/schema/User/index.js
+++ b/schema/User/index.js
@@ -1,0 +1,4 @@
+import resolvers from './resolvers';
+import typeDefs from './typeDefs';
+
+export { resolvers, typeDefs };

--- a/schema/User/typeDefs.js
+++ b/schema/User/typeDefs.js
@@ -16,24 +16,9 @@ const typeDefs = gql`
     followers: Followers
     external_urls: Url
     birthdate: String
-    counrty: String
+    country: String
     email: String
     product: String
-  }
-
-  type Image {
-    height: Int
-    url: String!
-    width: Int
-  }
-
-  type Followers {
-    href: String
-    total: Int
-  }
-
-  type Url {
-    spotify: String
   }
 `;
 

--- a/server.js
+++ b/server.js
@@ -1,9 +1,19 @@
 import { ApolloServer, gql } from 'apollo-server-express';
 import connect from 'connect';
 import query from 'qs-middleware';
-import User from './schema/User/typeDefs';
-import resolvers from './schema/User/resolvers';
+import {
+  typeDefs as Shared,
+  resolvers as SharedResolvers
+} from './schema/Shared';
+import { typeDefs as User, resolvers as UserResolvers } from './schema/User';
+import {
+  typeDefs as Artist,
+  resolvers as ArtistResolvers
+} from './schema/Artist';
+import { typeDefs as Album, resolvers as AlbumResolvers } from './schema/Album';
+import { typeDefs as Track, resolvers as TrackResolvers } from './schema/Track';
 import SpotifyAPI from './data-sources/Spotify';
+import { mergeDeep } from 'apollo-utilities';
 
 const GRAPHQL_PORT = 3001;
 
@@ -21,8 +31,14 @@ const Mutation = gql`
 `;
 
 const server = new ApolloServer({
-  typeDefs: [Query, Mutation, User],
-  resolvers,
+  typeDefs: [Query, Mutation, Shared, User, Artist, Album, Track],
+  resolvers: mergeDeep(
+    SharedResolvers,
+    UserResolvers,
+    ArtistResolvers,
+    AlbumResolvers,
+    TrackResolvers
+  ),
   dataSources: () => ({
     spotifyAPI: new SpotifyAPI()
   })


### PR DESCRIPTION
GraphQL queries for artist routes 

These routes are covered : 
<img width="603" alt="Screenshot 2019-05-27 at 18 10 15" src="https://user-images.githubusercontent.com/15238155/58432530-bd493d00-80aa-11e9-928c-e5505728163d.png">


https://developer.spotify.com/console/artists/